### PR TITLE
correction du lien vers chillo tech

### DIFF
--- a/src/views/attentes/mail-to-admin.hbs
+++ b/src/views/attentes/mail-to-admin.hbs
@@ -17,7 +17,7 @@
       <br />
       Achille MBOUGUENG,<br />
       Fondateur de
-      <a href='chillo.tech' _target='blank'>chillo.tech</a><br />
+      <a href='https://chillo.tech' _target='blank'>chillo.tech</a><br />
       <a href='https://wa.me/33761705745'>+33 7 6170 57 45</a>
     </p>
     <p class='links'>

--- a/src/views/avis/template-mail-to-user.hbs
+++ b/src/views/avis/template-mail-to-user.hbs
@@ -7,7 +7,7 @@
     <header>
       <h1>
         Bonjour 👋, Je suis Achille de
-        <a href='chillo.tech' _target='blank'>chillo.tech</a>
+        <a href='https://chillo.tech' _target='blank'>chillo.tech</a>
       </h1>
       <p>Nous venons de recevoir votre avis sur {{subject}}</p>
     </header>
@@ -21,7 +21,7 @@
         <p>Achille MBOUGUENG,</p>
         <p>
           Fondateur de
-          <a href='chillo.tech' _target='blank'>chillo.tech</a>
+          <a href='https://chillo.tech' _target='blank'>chillo.tech</a>
         </p>
         <a href='tel:+33761705745'>+33 7 6170 57 45</a> &nbsp;
         <a

--- a/src/views/formations/mail-to-admin.hbs
+++ b/src/views/formations/mail-to-admin.hbs
@@ -17,7 +17,7 @@
       <br />
       Achille MBOUGUENG,<br />
       Fondateur de
-      <a href='chillo.tech' _target='blank'>chillo.tech</a><br />
+      <a href='https://chillo.tech' _target='blank'>chillo.tech</a><br />
       <a href='https://wa.me/33761705745'>+33 7 6170 57 45</a>
     </p>
     <p class='links'>

--- a/src/views/formations/mail-to-candidate.hbs
+++ b/src/views/formations/mail-to-candidate.hbs
@@ -29,7 +29,7 @@
       Bien à vous,
       <br />
       Achille MBOUGUENG,<br />
-      Fondateur de <a href='chillo.tech' _target='blank'>chillo.tech</a>
+      Fondateur de <a href='https://chillo.tech' _target='blank'>chillo.tech</a>
       <br />
       <a href='https://wa.me/33761705745'>+33 7 6170 57 45</a>
     </p>

--- a/src/views/newsletters/template-mail-to-admin.hbs
+++ b/src/views/newsletters/template-mail-to-admin.hbs
@@ -30,7 +30,7 @@
       <br />
       Achille MBOUGUENG,<br />
       Fondateur de
-      <a href='chillo.tech' _target='blank'>chillo.tech</a><br />
+      <a href='https://chillo.tech' _target='blank'>chillo.tech</a><br />
       <a href='https://wa.me/33761705745'>+33 7 6170 57 45</a>
     </p>
     <p class='links'>

--- a/src/views/newsletters/template-mail-to-user.hbs
+++ b/src/views/newsletters/template-mail-to-user.hbs
@@ -10,7 +10,7 @@
         {{name}}👋,
         <br />
         Je suis Achille de
-        <a href='chillo.tech' _target='blank'>chillo.tech</a>
+        <a href='https://chillo.tech' _target='blank'>chillo.tech</a>
       </p>
       <p>
          <p>Nous venons de recevoir votre inscription à nos newsletters.</p>
@@ -21,7 +21,7 @@
       <br />
       Achille MBOUGUENG,<br />
       Fondateur de
-      <a href='chillo.tech' _target='blank'>chillo.tech</a><br />
+      <a href='https://chillo.tech' _target='blank'>chillo.tech</a><br />
       <a href='https://wa.me/33761705745'>+33 7 6170 57 45</a>
     </p>
     <p class='links'>

--- a/src/views/suggestions/template-mail-to-admin.hbs
+++ b/src/views/suggestions/template-mail-to-admin.hbs
@@ -18,7 +18,7 @@
       <br />
       Achille MBOUGUENG,<br />
       Fondateur de
-      <a href='chillo.tech' _target='blank'>chillo.tech</a><br />
+      <a href='https://chillo.tech' _target='blank'>chillo.tech</a><br />
       <a href='https://wa.me/33761705745'>+33 7 6170 57 45</a>
     </p>
     <p class='links'>

--- a/src/views/suggestions/template-mail-to-user.hbs
+++ b/src/views/suggestions/template-mail-to-user.hbs
@@ -10,7 +10,7 @@
         {{name}}👋,
         <br />
         Je suis Achille de
-        <a href='chillo.tech' _target='blank'>chillo.tech</a>
+        <a href='https://chillo.tech' _target='blank'>chillo.tech</a>
       </p>
       <p>
         Nous venons de recevoir votre suggestion de contenu: je vous en
@@ -26,7 +26,7 @@
       <br />
       Achille MBOUGUENG,<br />
       Fondateur de
-      <a href='chillo.tech' _target='blank'>chillo.tech</a><br />
+      <a href='https://chillo.tech' _target='blank'>chillo.tech</a><br />
       <a href='https://wa.me/33761705745'>+33 7 6170 57 45</a>
     </p>
     <p class='links'>

--- a/src/views/webinaire/mail-to-admin.hbs
+++ b/src/views/webinaire/mail-to-admin.hbs
@@ -16,7 +16,7 @@
       <br />
       Achille MBOUGUENG,<br />
       Fondateur de
-      <a href='chillo.tech' _target='blank'>chillo.tech</a><br />
+      <a href='https://chillo.tech' _target='blank'>chillo.tech</a><br />
       <a href='https://wa.me/33761705745'>+33 7 6170 57 45</a>
     </p>
     <p class='links'>


### PR DESCRIPTION
Dans les templates de mail, j'avais mis le href du lien vers chillo tech comme ca : href='chiilo.tech' sans le protocol, c'est pas bien

J'ai corrige et j'ai mis ca href='https://chillo.tech'